### PR TITLE
Add automated setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/bitbucket-role/tree/develop)
+- *Bitbucket can be installed unattended*
 
 ## [1.1.0](https://github.com/idealista/bitbucket-role/tree/1.1.0)
 [Full Changelog](https://github.com/idealista/bitbucket-role/compare/1.0.0...1.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/bitbucket-role/tree/develop)
-- *Bitbucket can be installed unattended*
+- *[#5](https://github.com/idealista/bitbucket-role/pull/5) Bitbucket can be installed unattended* @vitkhab
 
 ## [1.1.0](https://github.com/idealista/bitbucket-role/tree/1.1.0)
 [Full Changelog](https://github.com/idealista/bitbucket-role/compare/1.0.0...1.1.0)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ Use in a playbook:
 
 Look to the [defaults](defaults/main.yml) properties file to see the possible configuration properties.
 
+### Automated Bitbucket installation
+
+For first time installation you can define `bitbucket_setup_configuration` parameters and run playbook with `bitbucket_setup_run` variable set to `true`
+
+``` bash
+ansible-playbook bitbucket.yml -e 'bitbucket_setup_run=yes'
+```
+
+After first start configuration will be stored in database and all corresponding parameters in `bitbucket.properties` would be rewritten by Bitbucket. You don't need to use `bitbucket_setup_run` variable anymore.
+
+[More info](https://confluence.atlassian.com/bitbucketserver/automated-setup-for-bitbucket-server-776640098.html) on automated Bitbucket installation.
+
 ## Testing
 
 ### Using Vagrant as provider

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,13 @@ bitbucket_jmx:
 #   url: jdbc:oracle:thin:@//host:port/database
 #   user:
 #   password:
+
+## Sample setup configuration
+# bitbucket_setup_configuration:
+#   displayName: Bitbucket
+#   baseUrl: http://bitbucket.example.com:7990
+#   license: AAABKg0ODAoPeNptkFFrwjAUhd/zKwJ72R4iTXR2CIF...
+#   sysadmin_username: admin
+#   sysadmin_password: password
+#   sysadmin_displayName: Administrator
+#   sysadmin_emailAddress: admin@example.com

--- a/templates/bitbucket.properties.j2
+++ b/templates/bitbucket.properties.j2
@@ -12,3 +12,14 @@ jdbc.url={{ conf.url }}
 jdbc.user={{ conf.user }}
 jdbc.password={{ conf.password }}
 {% endif %}
+
+{% if bitbucket_setup_run is defined %}
+{% set setup = bitbucket_setup_configuration %}
+setup.displayName={{ setup.displayName }}
+setup.baseUrl={{ setup.baseUrl }}
+setup.license={{ setup.license }}
+setup.sysadmin.username={{ setup.sysadmin_username }}
+setup.sysadmin.password={{ setup.sysadmin_password }}
+setup.sysadmin.displayName={{ setup.sysadmin_displayName }}
+setup.sysadmin.emailAddress={{ setup.sysadmin_emailAddress }}
+{% endif %}


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

According to [documentaion](https://confluence.atlassian.com/bitbucketserver/automated-setup-for-bitbucket-server-776640098.html):
* Added commented out variable section to `main.yml`
* Added variable section in `bitbucket.properties` template
* Added usage info into `README.md`


### Benefits

* User can automate Bitbucket installation using ansible role.
* User can store license info in ansible vault and reuse it.

### Possible Drawbacks

There is no drawback I would know about

### Applicable Issues

* I know no possibility to test this option for idempotency. Because Bitbucket rewrites `bitbucket.properties` after first start.
* It is possible to store license information in `bitbucket.properties` after several playbook runs if `bitbucket_setup_run` set to `true` in configuration, not manually