### PR TITLE
Add minimal CentOS support

### DIFF
--- a/Dockerfiles/centos-java-ansible-git.Dockerfile
+++ b/Dockerfiles/centos-java-ansible-git.Dockerfile
@@ -1,0 +1,6 @@
+FROM centos:7
+
+RUN yum update -y && \
+    yum install -y wget && \
+    yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel && \
+    yum clean all

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This Ansible role installs Atlassian Bitbucket in a Debian environment and will 
 	- [Prerequisities](#prerequisities)
 	- [Installing](#installing)
 - [Usage](#usage)
+  - [With CentOS](#with-centos)
 - [Testing](#testing)
 - [Built With](#built-with)
 - [Versioning](#versioning)
@@ -59,7 +60,14 @@ Look to the [defaults](defaults/main.yml) properties file to see the possible co
 
 ### With CentOS
 
-Bitbucket needs at least git v2.2.0. Default CentOS repositories have older version of git. You can  install Git from source or IUS repository.
+Bitbucket needs at least git v2.2.0. Default CentOS repositories have older version of git. You can install Git from source or IUS repository.
+
+#### Java
+
+You may use `geerlingguy.java` or `idealista.java_role` for installing Java on you Bitbucket Server. CentOS stores Java on different path than Debian, so set variable for your Bitbucket Server:
+```yaml
+bitbucket_java_home: "/usr/lib/jvm/jre/"
+```
 
 #### Install Git from source
 You can install Git [manually](https://www.digitalocean.com/community/tutorials/how-to-install-git-on-centos-7).

--- a/README.md
+++ b/README.md
@@ -57,6 +57,45 @@ Use in a playbook:
 
 Look to the [defaults](defaults/main.yml) properties file to see the possible configuration properties.
 
+### With CentOS
+
+Bitbucket needs at least git v2.2.0. Default CentOS repositories have older version of git. You can  install Git from source or IUS repository.
+
+#### Install Git from source
+You can install Git [manually](https://www.digitalocean.com/community/tutorials/how-to-install-git-on-centos-7).
+
+Or using [geerlingguy.git](https://galaxy.ansible.com/geerlingguy/git) role.
+
+```yaml
+- name: Install git
+  hosts: bitbucket_server
+  become: yes
+  vars:
+    git_install_from_source: true
+    git_install_from_source_force_update: true
+    git_version: "2.19.2"
+  roles:
+    - { role: geerlingguy.git }
+```
+
+#### Install Git from IUS repository
+You can enable IUS repository [manually](https://ius.io/GettingStarted/) and then install `git2u`.
+
+Or use [centralpayment.repo-ius](https://github.com/centralpayment/ansible-role-repo-ius) role.
+
+```yaml
+- name: Install git
+  hosts: bitbucket_server
+  become: yes
+  roles:
+    - { role: centralpayment.repo-ius }
+  tasks:
+    - name: Install git from IUS
+      yum:
+        name: git2u
+        state: present
+```
+
 ## Testing
 
 ### Using Vagrant as provider

--- a/molecule.yml
+++ b/molecule.yml
@@ -69,6 +69,18 @@ docker:
       volume_mounts:
         - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
       command: '/lib/systemd/systemd'
+    - name: bitbucket.centos
+      ansible_groups:
+        - centos
+      dockerfile: ./Dockerfiles/centos-java-ansible-git.Dockerfile
+      image: centos-java-ansible-git
+      image_version: latest
+      privileged: True
+      cap_add:
+        - SYS_ADMIN
+      volume_mounts:
+        - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+      command: '/lib/systemd/systemd'
 
 verifier:
   name: goss

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,14 @@
 ---
 - name: Bitbucket | Install dependencies
+  yum:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items:
+    - "{{ bitbucket_dependencies }}"
+  when: ansible_os_family == "RedHat"
+
+- name: Bitbucket | Install dependencies
   apt:
     name: "{{ item }}"
     state: present
@@ -8,6 +17,7 @@
     cache_valid_time: 3600
   with_items:
     - "{{ bitbucket_dependencies }}"
+  when: ansible_os_family == "Debian"
 
 - name: Bitbucket | Ensure bitbucket group exists
   group:

--- a/tests/group_vars/centos.yml
+++ b/tests/group_vars/centos.yml
@@ -1,0 +1,2 @@
+---
+bitbucket_java_home: "/usr/lib/jvm/jre/"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

* Added new task to install dependencies in RedHat OS family
* Added usage info in `README.md` 


### Benefits

User can install bitbucket on CentOS or RHEL using asible role.

### Possible Drawbacks

There is no drawback I would know about

### Applicable Issues

RHEL and CentOS repositories have old version of git. User must use one of workarounds written in Readme.
