### PR TITLE
Make compatible with 5.21.0

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -52,3 +52,4 @@
     backup: yes
   notify: restart bitbucket
   tags: bitbucket_configure
+  when: bitbucket_version is version('7.0.0', '<')

--- a/templates/bin/_start-webapp.sh.j2
+++ b/templates/bin/_start-webapp.sh.j2
@@ -57,13 +57,19 @@ if echo $UMASK | grep -qv '0[2367]7$'; then
     fi
 fi
 
-MAX_OPEN_FILES=4096
+MAX_OPEN_FILES=6192
 if [ $(ulimit -n) -lt ${MAX_OPEN_FILES} ]; then
     echo -e "\nThe current open files limit is set to less than $MAX_OPEN_FILES\nAttempting to increase limit..."
     if ulimit -n $MAX_OPEN_FILES; then
         echo -e "\tLimit increased to $MAX_OPEN_FILES open files"
     else
-        echo -e "Warning: Open file limit could not be increased. You may experience problems under heavy load"
+        echo -e "\n Couldn't increase file limit to $MAX_OPEN_FILES\nTrying a lower number..."
+        MAX_OPEN_FILES=4096
+        if ulimit -n $MAX_OPEN_FILES; then
+          echo -e "\tLimit increased to $MAX_OPEN_FILES open files"
+        else
+          echo -e "Warning: Open file limit could not be increased. You may experience problems under heavy load"
+        fi
     fi
 fi
 
@@ -79,6 +85,12 @@ fi
 source $BIN_DIR/set-jmx-opts.sh
 if [ $? -ne 0 ]; then
     exit 1
+fi
+
+# Java 11 no longer supports setting sun.jnu.encoding via the command line. With nothing set in the environment
+# to influence sun.jnu.encoding it will typically default to ANSI_X3.4-1968 on Linux.
+if [ -z "$LANG" ] ; then
+    export LANG="en_US.UTF-8"
 fi
 
 JVM_LIBRARY_PATH="$INST_DIR/lib/native;$BITBUCKET_HOME/lib/native"
@@ -102,7 +114,7 @@ else
     if [ $? -eq 0 ]; then
         echo -e "The Bitbucket webapp has been started.\n"
         echo "If you cannot access Bitbucket within 3 minutes, or encounter other issues, check the troubleshooting guide at:"
-        echo "https://confluence.atlassian.com/display/BitbucketServerKB/Troubleshooting+Installation"
+        echo "https://go.atlassian.com/bbs-troubleshooting-installations"
     else
         if [ -f "$BITBUCKET_HOME/log/bitbucket.pid" ]; then
             # If the application failed to start, remove the PID file

--- a/templates/bin/set-jre-home.sh.j2
+++ b/templates/bin/set-jre-home.sh.j2
@@ -1,8 +1,15 @@
+# Uncomment and edit the line below to define JRE_HOME.
+# If you use the Bitbucket installer, this value will be automatically set to point to the bundled JRE.
+# Once a value is set here, existing JRE_HOME and JAVA_HOME values set in the environment will be overridden and ignored.
+# JRE_HOME=
+
+{% if bitbucket_java_home is defined %}
+JRE_HOME={{ bitbucket_java_home }}
+{% endif %}
+
+# Otherwise, use an existing installed JDK defined by JAVA_HOME
 if [ -z "$JRE_HOME" ]; then
-    if [ -z "$JAVA_HOME" ]; then
-        # If JRE_HOME and JAVA_HOME are not defined, edit this line to define JRE_HOME
-        JRE_HOME={{ bitbucket_java_home }}
-    elif [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/jre/bin/java" ]; then
+    if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/jre/bin/java" ]; then
         # If JAVA_HOME points to a valid JDK, use its JRE
         JRE_HOME="$JAVA_HOME/jre"
     elif [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
@@ -36,7 +43,12 @@ else
     return 1
 fi
 
+# This ensures that JAVA_HOME and JRE_HOME are consistent so that
+# both Bitbucket and the bundled search server use the same JVM.
+JAVA_HOME=$JRE_HOME
+
 # If we make it here, the Java environment looks good
 export JRE_HOME
+export JAVA_HOME
 export JAVA_BINARY
 export JAVA_VERSION


### PR DESCRIPTION

### Requirements

* Molecule tests pass OK with bitbucket 5.8.1 and 5.21.0

### Description of the Change

There were modifications by atlassian in bitbucket versions after 5.8.1, for which this role has been created:
* In 5.21.0 elasticsearch has been replaced by opensearch, which requires JAVA_HOME to be set. This requirement has been implemented by atlassian in original files, which are overwritten by the role. This patch synchronizes these atlassian modifications to the template file. The modification should be backwards compatible, it works also with 5.8.1.
* There are also other modifications in _start-webapp.sh.j2 template (MAX_OPEN_FILES, URL to troubleshooting, LANG environment variable set to en_US.UTF-8 if not set), which this patch synchronizes from original file. The modifications are backwards compatible, so they do not hurt having them also in older versions than 5.21.0
* Configuration of logrotate through the role modifies a file, which does not exist anymore after 6.x. This modification makes it conditional to apply the configuration only before version 6.x… This should be added for later versions, by creating the logback.xml file in bitbucket home, which now will be included by logback-spring.xml

### Benefits

Make the role work for bitbucket 5.21.0 and probably also versions in between.

### Possible Drawbacks

Logrotate configuration is not applied anymore after 6.x.

### Applicable Issues

